### PR TITLE
#13 Implement coroutine based processing model

### DIFF
--- a/src/main/kotlin/ru/ilyushkin/server/processing/coroutines/Coroutines.kt
+++ b/src/main/kotlin/ru/ilyushkin/server/processing/coroutines/Coroutines.kt
@@ -1,0 +1,15 @@
+package ru.ilyushkin.server.processing.coroutines
+
+/**
+ * Presents a set of coroutines
+ *
+ * @author Alex Ilyushkin
+ */
+interface Coroutines {
+
+    /**
+     * Runs through coroutine a runnable provided as parameter
+     * @param runnable
+     */
+    suspend fun execute(runnable: Runnable)
+}

--- a/src/main/kotlin/ru/ilyushkin/server/processing/coroutines/NewCoroutines.kt
+++ b/src/main/kotlin/ru/ilyushkin/server/processing/coroutines/NewCoroutines.kt
@@ -1,0 +1,27 @@
+package ru.ilyushkin.server.processing.coroutines
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Coroutines interface implementation that executes task through new coroutine
+ *
+ * @author Alex Ilyushkin
+ */
+class NewCoroutines(
+    private val context: CoroutineContext
+) : Coroutines {
+
+    /**
+     * Runs through new coroutine a runnable provided as parameter
+     *
+     * @param runnable
+     */
+    override suspend fun execute(runnable: Runnable) = coroutineScope {
+        launch(context) {
+            runnable.run()
+        }
+        Unit
+    }
+}

--- a/src/main/kotlin/ru/ilyushkin/server/processing/eventloop/CoroutineBasedEventLoop.kt
+++ b/src/main/kotlin/ru/ilyushkin/server/processing/eventloop/CoroutineBasedEventLoop.kt
@@ -1,0 +1,36 @@
+package ru.ilyushkin.server.processing.eventloop
+
+import kotlinx.coroutines.runBlocking
+import ru.ilyushkin.server.processing.coroutines.Coroutines
+import java.lang.Runnable
+import java.util.concurrent.BlockingQueue
+
+/**
+ * Event loop that executes queued tasks through coroutines
+ *
+ * @author Alex Ilyushkin
+ */
+class CoroutineBasedEventLoop(
+    private val eventsQueue: BlockingQueue<Runnable>,
+    private val coroutines: Coroutines,
+) : EventLoopProcessingModel {
+
+    /**
+     * Starts executing of queued tasks.
+     * Blocks current thread.
+     */
+    override fun start() {
+        runBlocking {
+            while (true) {
+                coroutines.execute(eventsQueue.take())
+            }
+        }
+    }
+
+    /**
+     * Puts [Runnable] provided as parameter to [BlockingQueue] to dispatch it by event loop
+     */
+    override fun execute(runnable: Runnable) {
+        eventsQueue.put(runnable)
+    }
+}

--- a/src/main/kotlin/ru/ilyushkin/server/processing/eventloop/EventLoopProcessingModel.kt
+++ b/src/main/kotlin/ru/ilyushkin/server/processing/eventloop/EventLoopProcessingModel.kt
@@ -1,0 +1,16 @@
+package ru.ilyushkin.server.processing.eventloop
+
+import ru.ilyushkin.server.processing.ProcessingModel
+
+/**
+ * Processing model realized as Event loop
+ * @see <a href="https://en.wikipedia.org/wiki/Event_loop">Event loop Wiki page</a>
+ * @author Alex Ilyushkin
+ */
+interface EventLoopProcessingModel : ProcessingModel {
+
+    /**
+     * Starts task executing
+     */
+    fun start()
+}

--- a/src/test/kotlin/ru/ilyushkin/server/processing/coroutines/NewCoroutinesTest.kt
+++ b/src/test/kotlin/ru/ilyushkin/server/processing/coroutines/NewCoroutinesTest.kt
@@ -1,0 +1,36 @@
+package ru.ilyushkin.server.processing.coroutines
+
+import io.mockk.*
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.lang.Runnable
+
+/**
+ * @author Alex Ilyushkin
+ */
+class NewCoroutinesTest {
+
+    @Test
+    @DisplayName("Runs through new coroutine created by thread context a runnable provided as parameter")
+    fun `execute test`() = runBlocking {
+        val runnable = mockk<Runnable> {
+            justRun { run() }
+        }
+        val coroutineContext = newSingleThreadContext("Test coroutine context")
+
+        val newCoroutines = NewCoroutines(
+            context = coroutineContext
+        )
+        newCoroutines.execute(runnable)
+        try {
+            //Wait for the coroutine job complete
+            coroutineContext.job.join()
+        } catch (ignore: IllegalStateException) {
+            //May be thrown when the coroutine job is already completed. Ignore it.
+        }
+
+        verify(exactly = 1) { runnable.run() }
+        confirmVerified(runnable)
+    }
+}

--- a/src/test/kotlin/ru/ilyushkin/server/processing/eventloop/CoroutineBasedEventLoopTest.kt
+++ b/src/test/kotlin/ru/ilyushkin/server/processing/eventloop/CoroutineBasedEventLoopTest.kt
@@ -1,0 +1,64 @@
+package ru.ilyushkin.server.processing.eventloop
+
+import io.mockk.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import ru.ilyushkin.server.processing.coroutines.Coroutines
+import java.util.concurrent.BlockingQueue
+
+/**
+ *
+ * @author Alex Ilyushkin
+ *
+ */
+class CoroutineBasedEventLoopTest {
+
+    @Test
+    @DisplayName("Starts to take tasks from queue and execute them through coroutines")
+    fun `start test`() {
+        val runnable = mockk<Runnable>()
+        val eventQueue = mockk<BlockingQueue<Runnable>> {
+            every { take() } returns runnable
+        }
+        val coroutines = mockk<Coroutines> {
+            //throw an exception to interrupt endless cycle of EventLoop
+            coJustRun { execute(runnable) } andThenThrows Exception()
+        }
+
+        val coroutineBasedEventLoop = CoroutineBasedEventLoop(
+            eventsQueue = eventQueue,
+            coroutines = coroutines,
+        )
+        assertThrows<Exception> { coroutineBasedEventLoop.start() }
+
+        coVerifySequence {
+            eventQueue.take()
+            coroutines.execute(runnable)
+            eventQueue.take()
+            coroutines.execute(runnable)
+        }
+        verify(exactly = 2) { eventQueue.take() }
+        coVerify(exactly = 2) { coroutines.execute(runnable) }
+        confirmVerified(runnable, eventQueue, coroutines)
+    }
+
+    @Test
+    @DisplayName("Puts runnable to event queue when `execute()` method is invoked")
+    fun `execute test`() {
+        val runnable = mockk<Runnable>()
+        val eventQueue = mockk<BlockingQueue<Runnable>> {
+            justRun { put(runnable) }
+        }
+        val coroutines = mockk<Coroutines>()
+
+        val coroutineBasedEventLoop = CoroutineBasedEventLoop(
+            eventsQueue = eventQueue,
+            coroutines = coroutines
+        )
+        coroutineBasedEventLoop.execute(runnable)
+
+        verify(exactly = 1) { eventQueue.put(runnable) }
+        confirmVerified(runnable, eventQueue, coroutines)
+    }
+}


### PR DESCRIPTION
Closes #13

Coroutine based processing model was implemented as event loop with task queue, to create "non-blocking" interface for current thread, because Kotlin requires `runBlocking()` call to bridge the non-coroutine world and the code with coroutines. `runBlocking()` method blocks current thread until all coroutines, created in this block, completed. 
More information: https://kotlinlang.org/docs/coroutines-basics.html#your-first-coroutine